### PR TITLE
Extract poll attachments creation, rebuild entire message for every interaction

### DIFF
--- a/votey/models.py
+++ b/votey/models.py
@@ -48,6 +48,7 @@ class Poll(BaseModel):
     anonymous = db.Column(db.Boolean, nullable=False, default=False)
     secret = db.Column(db.Boolean, nullable=False, default=False)
     vote_emoji = db.Column(db.Text, nullable=True)
+    author = db.Column(db.Text, nullable=True)
     options = db.relationship("Option", backref="poll", lazy="select")
     votes = db.relationship("Vote", backref="poll", lazy="select")
     ts = db.Column(db.Text, nullable=True)

--- a/votey/utils.py
+++ b/votey/utils.py
@@ -35,7 +35,7 @@ def batch(lst: List[T], n: int = 1) -> Iterable[List[T]]:
         yield lst[ndx : min(ndx + n, ln)]
 
 
-def get_footer(user_id: str, anonymous: bool, secret: bool) -> str:
+def get_footer(user_id: Optional[str], anonymous: bool, secret: bool) -> str:
     if secret:
         return "Poll creator and votes are hidden."
     if anonymous:


### PR DESCRIPTION
Potentially more expensive since we hit the DB a lot for every poll interaction (eg voting) which could cause some noticeable lag with high interactivity polls. But, since Slack changed something with the API underneath us this will have to do.

On the plus side, all message UI has been wrapped up into one method!